### PR TITLE
Get time derivative of body-frame linear velocity

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
@@ -220,7 +220,8 @@ void HMFossen::ApplyHydrodynamicForces(const math::Vector3 &_flowVelWorld)
 {
   const math::Vector3 linVel = this->link->GetRelativeLinearVel();
   const math::Vector3 angVel = this->link->GetRelativeAngularVel();
-  const math::Vector3 linAcc = this->link->GetRelativeLinearAccel();
+  // Take in account coriolis and centripetal term
+  const math::Vector3 linAcc = this->link->GetRelativeLinearAccel() - angVel.Cross(linVel);
   const math::Vector3 angAcc = this->link->GetRelativeAngularAccel();
 
   // Link's pose


### PR DESCRIPTION
link->GetRelativeLinearAccel is not the derivative of body-frame linear velocity.
Instead, it's the derivative of world-frame linear velocity expressed in body-frame.

#4 