### PR TITLE
workaround for Gazebo reporting wrong angular accelerations:

### DIFF
--- a/uuv_descriptions/models/rexrov/urdf/rexrov_base.xacro
+++ b/uuv_descriptions/models/rexrov/urdf/rexrov_base.xacro
@@ -155,6 +155,11 @@
           </hydrodynamic_model>
         </link>
       </plugin>
+
+      <!-- optional: plugin to test compare Gazebo's returned accelerations
+      <plugin name="${namespace}_test_plugin" filename="libaccelerations_test_plugin.so">
+        <link_name>${namespace}/base_link</link_name>
+      </plugin> -->
     </gazebo>
 
     <xacro:thruster_macro namespace="${namespace}" thruster_id="0">

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/HydrodynamicModel.hh
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/HydrodynamicModel.hh
@@ -47,14 +47,15 @@ class HydrodynamicModel : public BuoyantObject
 
   /// \brief Computation of the hydrodynamic forces
   public: virtual void ApplyHydrodynamicForces(
-                             const math::Vector3 &_flowVelWorld) = 0;
+    double time, const math::Vector3 &_flowVelWorld) = 0;
 
   /// \brief Prints parameters
   public: virtual void Print(std::string _paramName,
                              std::string _message = std::string()) = 0;
 
   /// \brief Filter acceleration (fix due to the update structure of Gazebo)
-  protected: void FilterAcc(Eigen::Vector6d _acc,
+  protected: void ComputeAcc(Eigen::Vector6d _velRel,
+                            double _time,
                             double _alpha = 0.3);
 
   /// \brief Returns true if all parameters are available from the SDF element
@@ -65,6 +66,12 @@ class HydrodynamicModel : public BuoyantObject
   /// only calls the update function at the beginning or at the end of a
   /// iteration of the physics engine
   protected: Eigen::Vector6d filteredAcc;
+
+  /// \brief Last timestamp (in seconds) at which ApplyHydrodynamicForces was called
+  protected: double lastTime;
+
+  /// \brief Last body-fixed relative velocity (nu_R in Fossen's equations)
+  protected: Eigen::Vector6d lastVelRel;
 
   /// \brief List of parameters needed from the SDF element
   protected: std::vector<std::string> params;
@@ -145,7 +152,7 @@ class HMFossen : public HydrodynamicModel
   protected: HMFossen(sdf::ElementPtr _sdf, physics::LinkPtr _link);
 
   /// \brief Computation of the hydrodynamic forces
-  public: virtual void ApplyHydrodynamicForces(
+  public: virtual void ApplyHydrodynamicForces(double time,
                             const math::Vector3 &_flowVelWorld);
 
   /// \brief Computes the added-mass Coriolis matrix Ca.

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/UnderwaterObjectPlugin.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/UnderwaterObjectPlugin.cc
@@ -176,6 +176,8 @@ void UnderwaterObjectPlugin::Init()
 /////////////////////////////////////////////////
 void UnderwaterObjectPlugin::Update(const common::UpdateInfo &_info)
 {
+  double time = _info.simTime.Double();
+
   for (std::map<gazebo::physics::LinkPtr,
        HydrodynamicModelPtr>::iterator it = models.begin();
        it != models.end(); ++it)
@@ -188,7 +190,7 @@ void UnderwaterObjectPlugin::Update(const common::UpdateInfo &_info)
 
     if (!std::isnan(linearAccel) && !std::isnan(angularAccel))
     {
-      hydro->ApplyHydrodynamicForces(this->flowVelocity);
+      hydro->ApplyHydrodynamicForces(time, this->flowVelocity);
       this->PublishRestoringForce(link);
       this->PublishHydrodynamicWrenches(link);
     }

--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/CMakeLists.txt
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/CMakeLists.txt
@@ -48,7 +48,12 @@ add_dependencies(underwater_object_ros_plugin underwater_object_plugin)
 add_library(joint_state_publisher src/JointStatePublisher.cc)
 target_link_libraries(joint_state_publisher ${catkin_LIBRARIES})
 
-install(TARGETS fin_ros_plugin thruster_ros_plugin underwater_object_ros_plugin joint_state_publisher
+add_library(accelerations_test_plugin
+  src/AccelerationsTestPlugin.cc
+)
+target_link_libraries(accelerations_test_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+
+install(TARGETS fin_ros_plugin thruster_ros_plugin underwater_object_ros_plugin joint_state_publisher accelerations_test_plugin
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/include/uuv_gazebo_ros_plugins/AccelerationsTestPlugin.hh
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/include/uuv_gazebo_ros_plugins/AccelerationsTestPlugin.hh
@@ -1,0 +1,70 @@
+#ifndef __UUV_GAZEBO_PLUGINS_ACCELERATIONS_TEST_PLUGIN_H__
+#define __UUV_GAZEBO_PLUGINS_ACCELERATIONS_TEST_PLUGIN_H__
+
+#include <map>
+#include <string>
+
+#include <gazebo/gazebo.hh>
+#include <gazebo/msgs/msgs.hh>
+
+#include <uuv_gazebo_plugins/HydrodynamicModel.hh>
+#include <uuv_gazebo_plugins/Def.hh>
+
+namespace gazebo
+{
+/// \brief Gazebo model plugin class for underwater objects
+class AccelerationsTestPlugin : public gazebo::ModelPlugin
+{
+  /// \brief Constructor
+  public: AccelerationsTestPlugin();
+
+  /// \brief Destructor
+  public: virtual ~AccelerationsTestPlugin();
+
+  // Documentation inherited.
+  public: virtual void Load(gazebo::physics::ModelPtr _model,
+                          sdf::ElementPtr _sdf);
+
+  // Documentation inherited.
+  public: virtual void Init();
+
+  /// \brief Update the simulation state.
+  /// \param[in] _info Information used in the update event.
+  public: void Update(const gazebo::common::UpdateInfo &_info);
+
+  /// \brief Connects the update event callback
+  protected: virtual void Connect();
+
+  /// \brief Update event
+  protected: gazebo::event::ConnectionPtr updateConnection;
+
+  /// \brief Pointer to the world plugin
+  protected: gazebo::physics::WorldPtr world;
+
+  /// \brief Pointer to the model structure
+  protected: gazebo::physics::ModelPtr model;
+
+  /// \brief Gazebo node
+  protected: gazebo::transport::NodePtr node;
+
+  /// \brief Link of test object
+  protected: physics::LinkPtr link;
+
+  // ROS things
+  private: boost::scoped_ptr<ros::NodeHandle> rosNode;
+
+  protected: ros::Publisher pub_accel_b_gazebo;
+  protected: ros::Publisher pub_accel_b_numeric;
+
+  protected: ros::Publisher pub_accel_w_gazebo;
+  protected: ros::Publisher pub_accel_w_numeric;
+
+  /// \brief Velocity of link with respect to world frame in previous time step.
+  Eigen::Vector6d last_w_v_w_b;
+
+  /// \brief Time stamp of previous time step.
+  common::Time lastTime;
+};
+}
+
+#endif  // __UUV_GAZEBO_PLUGINS_ACCELERATIONS_TEST_PLUGIN_H__

--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/AccelerationsTestPlugin.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/AccelerationsTestPlugin.cc
@@ -1,0 +1,181 @@
+// Copyright (c) 2016 The UUV Simulator Authors.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gazebo/gazebo.hh>
+#include <gazebo/physics/Collision.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/PhysicsEngine.hh>
+#include <gazebo/physics/Shape.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/math/Vector3.hh>
+
+#include <ros/ros.h>
+#include <geometry_msgs/Accel.h>
+
+#include <uuv_gazebo_ros_plugins/AccelerationsTestPlugin.hh>
+#include <uuv_gazebo_plugins/Def.hh>
+
+namespace gazebo {
+
+GZ_REGISTER_MODEL_PLUGIN(AccelerationsTestPlugin)
+
+/////////////////////////////////////////////////
+AccelerationsTestPlugin::AccelerationsTestPlugin()
+{
+}
+
+/////////////////////////////////////////////////
+AccelerationsTestPlugin::~AccelerationsTestPlugin()
+{
+  event::Events::DisconnectWorldUpdateBegin(this->updateConnection);
+}
+
+/////////////////////////////////////////////////
+void AccelerationsTestPlugin::Load(physics::ModelPtr _model,
+                                  sdf::ElementPtr _sdf)
+{
+  GZ_ASSERT(_model != NULL, "Invalid model pointer");
+  GZ_ASSERT(_sdf != NULL, "Invalid SDF element pointer");
+
+  this->model = _model;
+  this->world = _model->GetWorld();
+
+  // Initialize the transport node
+  this->node = transport::NodePtr(new transport::Node());
+  this->node->Init(this->world->GetName());
+
+  std::string link_name;
+  if (_sdf->HasElement("link_name"))
+    link_name = _sdf->GetElement("link_name")->Get<std::string>();
+  else
+  gzerr << "[TestPlugin] Please specify a link_name .\n";
+  this->link = this->model->GetLink(link_name);
+  if (this->link == NULL)
+    gzthrow("[TestPlugin] Could not find specified link \"" << link_name << "\".");
+
+  // Connect the update event callback
+  this->Connect();
+
+  // ROS:
+  if (!ros::isInitialized())
+  {
+    gzerr << "Not loading plugin since ROS has not been "
+          << "properly initialized.  Try starting gazebo with ros plugin:\n"
+          << "  gazebo -s libgazebo_ros_api_plugin.so\n";
+    return;
+  }
+
+  this->rosNode.reset(new ros::NodeHandle(""));
+
+  this->pub_accel_w_gazebo = this->rosNode->advertise<geometry_msgs::Accel>("accel_w_gazebo", 10);
+  this->pub_accel_w_numeric = this->rosNode->advertise<geometry_msgs::Accel>("accel_w_numeric", 10);
+
+  this->pub_accel_b_gazebo = this->rosNode->advertise<geometry_msgs::Accel>("accel_b_gazebo", 10);
+  this->pub_accel_b_numeric = this->rosNode->advertise<geometry_msgs::Accel>("accel_b_numeric", 10);
+}
+
+/////////////////////////////////////////////////
+void AccelerationsTestPlugin::Init()
+{
+  // Doing nothing for now
+}
+
+geometry_msgs::Accel accelFromEigen(const Eigen::Vector6d& acc)
+{
+  geometry_msgs::Accel amsg;
+  amsg.linear.x = acc[0];
+  amsg.linear.y = acc[1];
+  amsg.linear.z = acc[2];
+  amsg.angular.x = acc[3];
+  amsg.angular.y = acc[4];
+  amsg.angular.z = acc[5];
+  return amsg;
+}
+
+Eigen::Matrix3d Matrix3ToEigen(const math::Matrix3& m)
+{
+  Eigen::Matrix3d r;
+  r << m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2];
+  return r;
+}
+
+/////////////////////////////////////////////////
+void AccelerationsTestPlugin::Update(const common::UpdateInfo &_info)
+{
+  double dt = (_info.simTime - lastTime).Double();
+
+  // Link's pose
+  const math::Pose pose_w_b = this->link->GetWorldPose();
+
+  // Velocities of this link in link frame.
+  Eigen::Vector6d gazebo_b_v_w_b = EigenStack(
+    this->link->GetRelativeLinearVel(),
+    this->link->GetRelativeAngularVel());
+
+  // Velocities of this link in world frame
+  Eigen::Vector6d gazebo_w_v_w_b = EigenStack(
+    this->link->GetWorldLinearVel(),
+    this->link->GetWorldAngularVel());
+
+
+  // Accelerations of this link in world frame
+  Eigen::Vector6d gazebo_w_a_w_b = EigenStack(
+    this->link->GetWorldLinearAccel(),
+    this->link->GetWorldAngularAccel()
+  );
+
+  // Accelerations of this link in link frame
+  Eigen::Vector6d gazebo_b_a_w_b = EigenStack(
+    this->link->GetRelativeLinearAccel(),
+    this->link->GetRelativeAngularAccel()
+  );
+
+  // Numerically computed accelerations
+  math::Quaternion q_b_w = pose_w_b.rot.GetInverse();
+  math::Matrix3 R_b_w = q_b_w.GetAsMatrix3();
+
+  Eigen::Matrix3d R_b_w_eigen = Matrix3ToEigen(R_b_w);
+  Eigen::Matrix6d R6_b_w_eigen;
+  R6_b_w_eigen << R_b_w_eigen, Eigen::Matrix3d::Zero(),
+                  Eigen::Matrix3d::Zero(), R_b_w_eigen;
+
+  // Actual numeric differentiation
+  Eigen::Vector6d num_w_a_w_b = (gazebo_w_v_w_b - last_w_v_w_b)/dt;
+  Eigen::Vector6d num_b_a_w_b = R6_b_w_eigen*num_w_a_w_b;
+
+  // Publish all four variants via ROS for easy comparison
+  this->pub_accel_w_gazebo.publish(accelFromEigen(gazebo_w_a_w_b));
+  this->pub_accel_b_gazebo.publish(accelFromEigen(gazebo_b_a_w_b));
+
+  this->pub_accel_w_numeric.publish(accelFromEigen(num_w_a_w_b));
+  this->pub_accel_b_numeric.publish(accelFromEigen(num_b_a_w_b));
+
+  last_w_v_w_b = gazebo_w_v_w_b;
+  lastTime = _info.simTime;
+}
+
+/////////////////////////////////////////////////
+void AccelerationsTestPlugin::Connect()
+{
+  // Connect the update event
+  this->updateConnection = event::Events::ConnectWorldUpdateBegin(
+    boost::bind(&AccelerationsTestPlugin::Update,
+                    this, _1));
+}
+
+}


### PR DESCRIPTION
use numerical differentiation of velocities

This fixes the problem of Gazebo crashing for certain values of added mass (especially added moments of inertia)

Signed-off-by: Sebastian Scherer <Sebastian.Scherer2@de.bosch.com>