### PR TITLE
Fix oberon_description/package.xml dependency name

### DIFF
--- a/uuv_manipulators/oberon/oberon_description/package.xml
+++ b/uuv_manipulators/oberon/oberon_description/package.xml
@@ -11,8 +11,8 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>uuv_manipulators_gazebo_ros_plugins</build_depend>
+  <build_depend>uuv_gazebo_ros_plugins</build_depend>
   <build_depend>gazebo_plugins</build_depend>
-  <run_depend>uuv_manipulators_gazebo_ros_plugins</run_depend>
+  <run_depend>uuv_gazebo_ros_plugins</run_depend>
   <run_depend>gazebo_plugins</run_depend>
 </package>


### PR DESCRIPTION
Hi,

Minor `rosdep` thing. Just a package rename on `oberon_description` that I found when attempting to run `rosdep` on your repo to satisfy the dependencies. Note that I took a best guess at what I thought the package should be so feel free to adjust as necessary, or close if the dependency is actually correct.

Here's the output I was getting before:

```
pdinh@computer:~/uuv_workspace/src/uuv_simulator $ rosdep install --from-paths . --ignore-src
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
oberon_description: Cannot locate rosdep definition for [uuv_manipulators_gazebo_ros_plugins]
```

and after

```
pdinh@computer:~/uuv_workspace/src/uuv_simulator$ rosdep install --from-paths . --ignore-src
#All required rosdeps installed successfully
```