### PR TITLE
Make gazebo thruster plugin and thruster manager more general by allowing the thruster axis to be other than the x-axis

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/ThrusterPlugin.hh
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/ThrusterPlugin.hh
@@ -128,6 +128,9 @@ class ThrusterPlugin : public gazebo::ModelPlugin
 
   /// \brief Optional: Propeller angular velocity efficiency term
   protected: double propellerEfficiency;
+
+  /// \brief The axis about which the thruster rotates
+  protected: math::Vector3 thrusterAxis;
 };
 }
 #endif  // __UUV_GAZEBO_PLUGINS_THRUSTER_PLUGIN_HH__


### PR DESCRIPTION
- Updated the thruster plugin to pull the thruster joint axes from the robot description parameter. If 
for some reason the robot description parameter isn't available then it'll fall back to the old behavior 
of hardcoding it to be the x-axis
- Update the gazebo ThrusterPlugin to use Gazebo's Joint API to get the thruster joints' 