### PR TITLE
Fix metapackages

### DIFF
--- a/uuv_manipulators/oberon4/oberon4/package.xml
+++ b/uuv_manipulators/oberon4/oberon4/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>oberon4</name>
   <version>0.5.0</version>
   <description>The oberon4 package</description>

--- a/uuv_manipulators/oberon4/oberon4/package.xml
+++ b/uuv_manipulators/oberon4/oberon4/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>oberon4_control</exec_depend>
+  <exec_depend>oberon4_description</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/uuv_manipulators/oberon7/oberon7/package.xml
+++ b/uuv_manipulators/oberon7/oberon7/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>oberon7</name>
   <version>0.5.0</version>
   <description>Meta-package for the Oberon 7, a mock-up robotic manipulator inspired on the Schilling Robotics Orion 7P</description>

--- a/uuv_manipulators/oberon7/oberon7/package.xml
+++ b/uuv_manipulators/oberon7/oberon7/package.xml
@@ -12,6 +12,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>oberon7_control</exec_depend>
+  <exec_depend>oberon7_description</exec_depend>
+
   <export>
     <metapackage/>
   </export>

--- a/uuv_manipulators/oberon7/oberon7/package.xml
+++ b/uuv_manipulators/oberon7/oberon7/package.xml
@@ -12,4 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <export>
+    <metapackage/>
+  </export>
 </package>

--- a/uuv_manipulators/uuv_manipulators_commons/uuv_manipulators_commons/package.xml
+++ b/uuv_manipulators/uuv_manipulators_commons/uuv_manipulators_commons/package.xml
@@ -12,6 +12,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>uuv_manipulators_control</exec_depend>
+  <exec_depend>uuv_manipulators_description</exec_depend>
+  <exec_depend>uuv_manipulators_kinematics</exec_depend>
+  <exec_depend>uuv_manipulators_msgs</exec_depend>
+
   <export>
     <metapackage/>
   </export>

--- a/uuv_manipulators/uuv_manipulators_commons/uuv_manipulators_commons/package.xml
+++ b/uuv_manipulators/uuv_manipulators_commons/uuv_manipulators_commons/package.xml
@@ -11,4 +11,8 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+    <metapackage/>
+  </export>
 </package>

--- a/uuv_manipulators/uuv_manipulators_commons/uuv_manipulators_commons/package.xml
+++ b/uuv_manipulators/uuv_manipulators_commons/uuv_manipulators_commons/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>uuv_manipulators_commons</name>
   <version>0.5.0</version>
   <description>Common nodes and configurations for underwater manipulators.</description>

--- a/uuv_simulator/package.xml
+++ b/uuv_simulator/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>uuv_simulator</name>
   <version>0.5.0</version>
   <description>uuv_simulator contains Gazebo plugins and ROS packages for modeling and simulating unmanned underwater vehicles</description>

--- a/uuv_simulator/package.xml
+++ b/uuv_simulator/package.xml
@@ -18,6 +18,29 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>uuv_assistants</exec_depend>
+  <exec_depend>uuv_auv_control_allocator</exec_depend>
+  <exec_depend>uuv_control_cascaded_pid</exec_depend>
+  <exec_depend>uuv_control_msgs</exec_depend>
+  <exec_depend>uuv_control_utils</exec_depend>
+  <exec_depend>uuv_thruster_manager</exec_depend>
+  <exec_depend>uuv_trajectory_control</exec_depend>
+  <exec_depend>uuv_descriptions</exec_depend>
+  <exec_depend>uuv_gazebo</exec_depend>
+  <exec_depend>uuv_gazebo_plugins</exec_depend>
+  <exec_depend>uuv_gazebo_ros_plugins</exec_depend>
+  <exec_depend>uuv_gazebo_ros_plugins_msgs</exec_depend>
+  <exec_depend>oberon4</exec_depend>
+  <exec_depend>oberon7</exec_depend>
+  <exec_depend>uuv_manipulators_commons</exec_depend>
+  <exec_depend>uuv_sensor_plugins_ros_msgs</exec_depend>
+  <exec_depend>uuv_sensor_ros_plugins</exec_depend>
+  <exec_depend>uuv_teleop</exec_depend>
+  <exec_depend>uuv_tutorials</exec_depend>
+  <exec_depend>uuv_world_plugins</exec_depend>
+  <exec_depend>uuv_world_ros_plugins</exec_depend>
+  <exec_depend>uuv_world_ros_plugins_msgs</exec_depend>
+
   <export>
     <metapackage/>
   </export>

--- a/uuv_simulator/package.xml
+++ b/uuv_simulator/package.xml
@@ -18,4 +18,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <export>
+    <metapackage/>
+  </export>
 </package>

--- a/uuv_tutorials/uuv_tutorials/package.xml
+++ b/uuv_tutorials/uuv_tutorials/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>uuv_tutorials</name>
   <version>0.5.0</version>
   <description>Meta package for all templates and tutorials.</description>

--- a/uuv_tutorials/uuv_tutorials/package.xml
+++ b/uuv_tutorials/uuv_tutorials/package.xml
@@ -17,6 +17,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <export>
-
+    <metapackage/>
   </export>
 </package>

--- a/uuv_tutorials/uuv_tutorials/package.xml
+++ b/uuv_tutorials/uuv_tutorials/package.xml
@@ -16,6 +16,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>uuv_tutorial_disturbances</exec_depend>
+  <exec_depend>uuv_tutorial_dp_controller</exec_depend>
+  <exec_depend>uuv_tutorial_seabed_world</exec_depend>
+
   <export>
     <metapackage/>
   </export>


### PR DESCRIPTION
Add missing metadata to metapackages. These data are required by tools that rely on them (e.g: bloom)

Reference: http://wiki.ros.org/catkin/package.xml#Metapackages

Signed-off-by: Gabriel Arjones <arjones@arjones.com>