### PR TITLE
Flipped GPS latitude,longitude so that latitude increases when going North…

### DIFF
--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/GPSROSPlugin.cc
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/GPSROSPlugin.cc
@@ -75,8 +75,8 @@ bool GPSROSPlugin::OnUpdateGPS()
   this->gpsMessage.header.stamp.nsec = currentTime.nsec;
 
   // Copy the output of Gazebo's GPS sensor into a NavSatFix message
-  this->gpsMessage.latitude = this->gazeboGPSSensor->Latitude().Degree();
-  this->gpsMessage.longitude = this->gazeboGPSSensor->Longitude().Degree();
+  this->gpsMessage.latitude = -this->gazeboGPSSensor->Latitude().Degree();
+  this->gpsMessage.longitude = -this->gazeboGPSSensor->Longitude().Degree();
   this->gpsMessage.altitude = this->gazeboGPSSensor->Altitude();
 
   this->rosSensorOutputPub.publish(this->gpsMessage);


### PR DESCRIPTION
… and longitude increases when going east

I found that, as the vessel moved East (positive red X-axis in Gazebo), the longitude decreased. Similarly for latitude and Northward motion. So I multiplied the GPS latitude and longitude to fix it. The example videos below show the change I made. I'm using the ENU frame.

"gps.mp4" show the simulation without the commit. "gps-changed.mp4" show the simulation with the commit.

[Example videos](https://drive.google.com/open?id=14H9x3mf4z_HZZqpbhIBtkkXWq76fJe8_)
