### PR TITLE
Changed frame_id for GPS to use the link mentioned in the URDF files

### DIFF
--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/GPSROSPlugin.cc
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/GPSROSPlugin.cc
@@ -40,7 +40,7 @@ void GPSROSPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
     this->sensorOutputTopic, 10);
 
   // Set the frame ID
-  this->gpsMessage.header.frame_id = this->robotNamespace;
+  this->gpsMessage.header.frame_id = this->robotNamespace + "/gps_link";
   // TODO: Get the position covariance from the GPS sensor
   this->gpsMessage.position_covariance_type =
     sensor_msgs::NavSatFix::COVARIANCE_TYPE_KNOWN;


### PR DESCRIPTION
I'm using a localization node (navsat_transform_node) that transforms the GPS coordinates into the vessel's "odom" frame. It relies on the NavSatFix's frame_id. GPSROSPlugin.cc sets the frame_id to be the vessel's namespace but the URDF files set the link names to be "namespace/gps_link".