### PR TITLE
Changed submergedHeight calculation to be more precise

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
@@ -136,22 +136,16 @@ void BuoyantObject::GetBuoyancyForce(const ignition::math::Pose3d &_pose,
     GZ_ASSERT(this->waterLevelPlaneArea > 0.0,
       "Water level plane area must be greater than zero");
 
-    if (z - height / 2.0 >= -this->submergedHeight && !this->isSurfaceVesselFloating)
-    {
+    if (z > height / 2.0) {
       // Vessel is completely out of the water
       buoyancyForce = ignition::math::Vector3d(0, 0, 0);
-      buoyancyTorque = ignition::math::Vector3d(0, 0, 0);      
+      buoyancyTorque = ignition::math::Vector3d(0, 0, 0);
       return;
-    }
-    else if (z - height / 2.0 < -this->submergedHeight && !this->isSurfaceVesselFloating)
-    {
+    } else if (z < -height / 2.0) {
       curSubmergedHeight = this->boundingBox.ZLength();
-    }      
-    else
-    { 
-      curSubmergedHeight = this->submergedHeight;
-      this->isSurfaceVesselFloating = true;
-    }
+    } else {
+      curSubmergedHeight = height / 2.0 - z;
+    }//else
                   
     volume = curSubmergedHeight * this->waterLevelPlaneArea;
     buoyancyForce = ignition::math::Vector3d(0, 0, volume * this->fluidDensity * this->g);


### PR DESCRIPTION
The submerged height calculation for surface vessels doesn't seem precise. That is, if the vessel sinks low enough, only then would the submerged height be considered large enough to warrant a buoyancy force. This force would accelerate the vessel upward. Then the vessel would fall back down until the submerged height would again be considered large enough to warrant a buoyancy force.

This commit changes the calculation of the submerged height so the submerged height increases as the vessel sinks into the water. This results in a proportionally increasing buoyancy force and the vessel not jumping up and down.

The image below shows the linear accelerations (as measured by a simulated IMU sensor) without this commit. The Z-acceleration starts near zero (ish) representing the vessel in the middle of its jump. Then the Z-acceleration jumps to 156 m/s^2 when the buoyancy force is applied.

![linear-acc](https://user-images.githubusercontent.com/11712824/41727927-8e4ee784-7543-11e8-9181-421e7bcb0fc3.png)
