### PR TITLE
Install URDF folder

### DIFF
--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 find_package(catkin REQUIRED
-  uuv_gazebo_plugins  
+  uuv_gazebo_plugins
   sensor_msgs
   geometry_msgs
   std_msgs
@@ -222,6 +222,6 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/
 )
 
 # Install mesh files
-install(DIRECTORY meshes
+install(DIRECTORY meshes urdf
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
         PATTERN "*~" EXCLUDE)


### PR DESCRIPTION
when using an install workspace, was unable to call `roslaunch uuv_descriptions upload_rexrov.launch` because the urdf folder was not targeted for install:
```
No such file or directory: ${CATKIN_WS_PATH}/install/share/uuv_sensor_ros_plugins/urdf/sensor_snippets.xacro None None
when processing file: ${CATKIN_WS_PATH}/install/share/uuv_descriptions/models/rexrov/urdf/rexrov_base.xacro
included from: ${CATKIN_WS_PATH}/install/share/uuv_descriptions/models/rexrov/robots/rexrov_default.xacro
while processing ${CATKIN_WS_PATH}/install/share/uuv_descriptions/models/rexrov/launch/upload_rexrov_default.launch:
Invalid <param> tag: Cannot load command parameter [robot_description]: command [/opt/ros/kinetic/lib/xacro/xacro '${CATKIN_WS_PATH}/install/share/uuv_descriptions/models/rexrov/robots/rexrov_default.xacro' --inorder           debug:=0           namespace:=rexrov           inertial_reference_frame:=world] returned with code [2]. 

Param xml is <param command="$(find xacro)/xacro '$(find uuv_descriptions)/models/rexrov/robots/rexrov_$(arg mode).xacro' --inorder           debug:=$(arg debug)           namespace:=$(arg namespace)           inertial_reference_frame:=world" name="robot_description"/>
The traceback for the exception was written to the log file
```