### PR TITLE
Fix: Dynamic TAM.yaml naming during TAM file generation

### DIFF
--- a/uuv_control/uuv_thruster_manager/launch/thruster_manager.launch
+++ b/uuv_control/uuv_thruster_manager/launch/thruster_manager.launch
@@ -28,6 +28,9 @@
         <rosparam param="output_dir" subst_value="true">
           $(arg output_dir)
         </rosparam>
+        <rosparam param="tam_file" subst_value="true">
+          $(arg tam_file)
+        </rosparam>
       </node>
     </group>
 

--- a/uuv_control/uuv_thruster_manager/src/uuv_thrusters/thruster_manager.py
+++ b/uuv_control/uuv_thruster_manager/src/uuv_thrusters/thruster_manager.py
@@ -48,6 +48,8 @@ class ThrusterManager:
         # available
         self._ready = False
 
+        # Acquiring TAM file location
+        self.tam_file = rospy.get_param('~tam_file')
         # Acquiring the namespace of the vehicle
         self.namespace = rospy.get_namespace()
         if self.namespace[-1] != '/':
@@ -169,7 +171,7 @@ class ThrusterManager:
 
         # If an output directory was provided, store matrix for further use
         if self.output_dir is not None:
-            with open(join(self.output_dir, 'TAM.yaml'), 'w') as yaml_file:
+            with open(self.tam_file, 'w') as yaml_file:
                 yaml_file.write(
                     yaml.safe_dump(
                         dict(tam=self.configuration_matrix.tolist())))
@@ -284,11 +286,11 @@ class ThrusterManager:
 
         # If an output directory was provided, store matrix for further use
         if self.output_dir is not None and not recalculate:
-            with open(join(self.output_dir, 'TAM.yaml'), 'w') as yaml_file:
+            with open(self.tam_file, 'w') as yaml_file:
                 yaml_file.write(
                     yaml.safe_dump(
                         dict(tam=self.configuration_matrix.tolist())))
-            print 'TAM saved in <%s>' % join(self.output_dir, 'TAM.yaml')
+            print 'TAM saved in <%s>' % self.tam_file
         elif recalculate:
             print 'Recalculate flag on, matrix will not be stored in TAM.yaml'
         else:


### PR DESCRIPTION
Fixes problem where a specified tam_file name is not used when
generating a new TAM matrix, thus overwriting old TAM.yaml files.

Change on
uuv_control/uuv_thruster_manager/launch/thruster_manager.launch:
Adds rosparam with argument tam_file for the rosparameter server.

Change on
uuv_control/uuv_thruster_manager/src/uuv_thrusters/thruster_manager.py:

TAM filename is obtained through rosparameter server in constructor.
The TAM filename replaces both cases of opening a YAML file for
writing the new TAM matrix.