### PR TITLE
Fix bug where thruster axis is determined incorrectly if it rotates a…

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/ThrusterPlugin.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/ThrusterPlugin.cc
@@ -186,22 +186,6 @@ void ThrusterPlugin::Load(physics::ModelPtr _model,
 #else
   this->thrusterAxis = this->joint->GetWorldPose().rot.Ign().RotateVectorReverse(this->joint->GetGlobalAxis(0).Ign());
 #endif
-
-  // this axis can contain non-zero x,y,z elements due to
-  // numerical precision errors, so instead use it to
-  // select the appropriate joint axis.
-  if (this->thrusterAxis.X() == this->thrusterAxis.Max())
-  {
-    this->thrusterAxis = ignition::math::Vector3d::UnitX;
-  }
-  else if (this->thrusterAxis.Y() == this->thrusterAxis.Max())
-  {
-    this->thrusterAxis = ignition::math::Vector3d::UnitY;
-  }
-  else
-  {
-    this->thrusterAxis = ignition::math::Vector3d::UnitZ;
-  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
I found a bug in the code I PR'd awhile back where if the thruster rotates about a negative axis(i.e. `0 0 -1` etc) the thruster axis will not be determined correctly. Pretty easy fix.