### PR TITLE
uuv_descriptions: add xacro as a runtime dependency

### DIFF
--- a/uuv_descriptions/package.xml
+++ b/uuv_descriptions/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>uuv_gazebo_ros_plugins</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>uuv_assistants</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
If xacro is not installed then it is not possible to spawn ROVs using upload_rexrov.launch.