### PR TITLE
Added DepthCameraPlugin target_link_library so that

### DIFF
--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
@@ -210,7 +210,7 @@ list(APPEND UUV_SENSOR_ROS_PLUGINS_LIST uuv_gazebo_ros_rpt_plugin)
 ###############################################################################
 
 add_library(uuv_gazebo_ros_camera_plugin src/UnderwaterCameraROSPlugin.cc)
-target_link_libraries(uuv_gazebo_ros_camera_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+target_link_libraries(uuv_gazebo_ros_camera_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} DepthCameraPlugin)
 add_dependencies(uuv_gazebo_ros_camera_plugin ${catkin_EXPORTED_TARGETS})
 list(APPEND UUV_SENSOR_ROS_PLUGINS_LIST uuv_gazebo_ros_camera_plugin)
 


### PR DESCRIPTION
Underwater Camera Plugin does not throw a
'undefined symbol: _ZTIN6gazebo17DepthCameraPluginE' exception.
Signed-off-by: Fletcher F Thompson <fletcherthompsonx@gmail.com>