### PR TITLE
factorial has been removed from scipy.misc in version 1.3.0.

### DIFF
--- a/uuv_control/uuv_trajectory_control/src/uuv_trajectory_generator/path_generator/bezier_curve.py
+++ b/uuv_control/uuv_trajectory_control/src/uuv_trajectory_generator/path_generator/bezier_curve.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 
 import numpy as np
-from scipy.misc import factorial
+try:
+    from scipy.misc import factorial
+except ImportError as error:
+    # factorial has been removed from scipy.misc in version 1.3.0.
+    from scipy.special import factorial
+
 
 
 class BezierCurve(object):


### PR DESCRIPTION
factorial has been moved from misc to special. The usage of factorial from misc is deprecated since Scipy 1.0.0. In Version 1.3.0 it has been removed from misc.
This should fix issue #402