### PR TITLE
Industrial_ci updated their default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - env: AFTER_SCRIPT='sh .uuv_ci_config/run_tests.sh' USE_DEB=true ROS_DISTRO=lunar ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true BEFORE_SCRIPT='sh .uuv_ci_config/ros_$ROS_DISTRO.sh'
     
 install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+  - git clone --depth 1 https://github.com/ros-industrial/industrial_ci.git .ci_config -b legacy
 script:
   - source .ci_config/travis.sh
 notifications:


### PR DESCRIPTION
Industrial_ci updated their default branch and they added breaking changes. The old behavior is restored by cloning the legacy branch instead of the master branch.
This PR fixes #404