### PR TITLE
Switched running the tests to the default industrial_ci test runner.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ env:
     - CATKIN_LINT_ARGS="--ignore link_directory"
 matrix:
   include:
-    - env: PRERELEASE=true USE_DEB=true ROS_DISTRO=kinetic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true BEFORE_SCRIPT='sh .uuv_ci_config/ros_$ROS_DISTRO.sh'
-    - env: AFTER_SCRIPT='sh .uuv_ci_config/run_tests.sh' USE_DEB=true ROS_DISTRO=kinetic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true BEFORE_SCRIPT='sh .uuv_ci_config/ros_$ROS_DISTRO.sh'
-    - env: PRERELEASE=true USE_DEB=true ROS_DISTRO=melodic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true BEFORE_SCRIPT='sh .uuv_ci_config/ros_$ROS_DISTRO.sh'
-    - env: AFTER_SCRIPT='sh .uuv_ci_config/run_tests.sh' USE_DEB=true ROS_DISTRO=melodic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true BEFORE_SCRIPT='sh .uuv_ci_config/ros_$ROS_DISTRO.sh'
+    - env: PRERELEASE=true USE_DEB=true ROS_DISTRO=kinetic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true ROS_DISTRO=kinetic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: PRERELEASE=true USE_DEB=true ROS_DISTRO=melodic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true ROS_DISTRO=melodic ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
   
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config -b legacy


### PR DESCRIPTION
Is it necessary to run the tests explicitly with the run_tests.sh shell script? I have changed running the tests to the default industrial_ci test runner. The tests seem to run just fine. I think this PR is necessary, because catkin_tools is not released for Ubuntu 20.04, yet. In my opinion, even if catkin_tools will be released it is more future proof to just let industrial_ci handle running the tests.
I have also removed running the before_script. It would install catkin_tools, which is not needed anymore and other stuff, which is not needed at all in the build pipeline.
If this PR will be merged it might make sense to delete the unused shell scripts. However, it might also make sense keep them, to be able to quickly setup uuv_simulator locally.