### PR TITLE
Convert rospy Time difference to seconds to compare with a timeout value

### DIFF
--- a/uuv_control/uuv_thruster_manager/scripts/thruster_allocator.py
+++ b/uuv_control/uuv_thruster_manager/scripts/thruster_allocator.py
@@ -66,7 +66,7 @@ class ThrusterAllocatorNode(ThrusterManager):
             if self.config['timeout'] > 0:
                 # If a timeout is set, zero the outputs to the thrusters if
                 # there is no command signal for the length of timeout
-                if rospy.Time.now() - self.last_update > self.config['timeout']:
+                if (rospy.Time.now() - self.last_update).to_sec() > self.config['timeout']:
                     print('Turning thrusters off - inactive for too long')
                     if self.thrust is not None:
                         self.thrust.fill(0)


### PR DESCRIPTION
Hi UUV simulator authors,

Thanks for this amazing work!

Could you please review this pull request on the issue below?

Issue: Comparing two rospy `Time` instances, in thruster-allocator, doesn't produce an appropriate duration when comparing with a configurable timeout value. Error thrown:

```
TypeError: Cannot compare to non-Duration
```

Fix: This fix converts the `Time` difference to _seconds_ so as to have a valid comparison with a timeout value.