### PR TITLE
Corrected a typo in a variable name (claStall) of the LiftDragModel

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/LiftDragModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/LiftDragModel.cc
@@ -247,14 +247,24 @@ ignition::math::Vector3d LiftDragTwoLines::compute(const ignition::math::Vector3
     double sumAlpha = alpha + this->alphaStall;
     cl = -this->cla * this->alphaStall +
         this->claStall * sumAlpha;
-    cd = -this->cda * this->alphaStall +
-        this->cdaStall * sumAlpha;
+    cd = this->cda * this->alphaStall +
+        -this->cdaStall * sumAlpha;
   }
   else
   {
     // no stall
-    cd = this->cda * alpha;
-    cl = this->cla * alpha;
+    // angle of attack > -a0
+    if (alpha > 0)
+    {
+        cd = this->cda * alpha;
+        cl = this->cla * alpha;
+    }
+    // angle of attack <= -a0
+    else
+    {
+        cd = -this->cda * alpha;
+        cl = this->cla * alpha;
+    }
   }
 
   double lift = cl*q*this->area;

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/LiftDragModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/LiftDragModel.cc
@@ -246,7 +246,7 @@ ignition::math::Vector3d LiftDragTwoLines::compute(const ignition::math::Vector3
     // stall
     double sumAlpha = alpha + this->alphaStall;
     cl = -this->cla * this->alphaStall +
-        this->cdaStall * sumAlpha;
+        this->claStall * sumAlpha;
     cd = -this->cda * this->alphaStall +
         this->cdaStall * sumAlpha;
   }


### PR DESCRIPTION
Dear UUV Sim Devs,

I was playing around with the Lift/Drag models for the fins and I realised a couple of things:

- A typo in a variable name (cdaStall instead of claStall) in the LiftDragModel.cc file
- A non-realistic model for the Drag component (two lines approximation)

Concerning the two lines model and the Drag component, it is consistent to use the same "S" shaped graph for both the Lift coefficient CL=f(alpha) and the Drag coefficient CD=f(alpha), as described [http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics](here). When I refer to "S" shaped graph, I mean the Cl vs alpha graph like presented [http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics](here).

However, it is not physically correct to have a drag vector oriented along the inertial velocity of the sub when the alpha is negative: it should always be oriented opposite to the inertial velocity (as shown [http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics](here) whatever the alpha value.
Therefore I have updated the code to generate a "V" shaped two lines approximation for the drag component (as shown [http://airfoiltools.com/airfoil/details?airfoil=naca0015-il](here), CD vs alpha).

Best regards,

Achille