### PR TITLE
Updated the liftdrag two lines model for the drag component to make it more realistic

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/LiftDragModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/LiftDragModel.cc
@@ -247,14 +247,24 @@ ignition::math::Vector3d LiftDragTwoLines::compute(const ignition::math::Vector3
     double sumAlpha = alpha + this->alphaStall;
     cl = -this->cla * this->alphaStall +
         this->cdaStall * sumAlpha;
-    cd = -this->cda * this->alphaStall +
-        this->cdaStall * sumAlpha;
+    cd = this->cda * this->alphaStall +
+        -this->cdaStall * sumAlpha;
   }
   else
   {
     // no stall
-    cd = this->cda * alpha;
-    cl = this->cla * alpha;
+    // angle of attack > -a0
+    if (alpha > 0)
+    {
+        cd = this->cda * alpha;
+        cl = this->cla * alpha;
+    }
+    // angle of attack <= -a0
+    else
+    {
+        cd = -this->cda * alpha;
+        cl = this->cla * alpha;
+    }
   }
 
   double lift = cl*q*this->area;


### PR DESCRIPTION
Dear UUV Sim Devs,

I was playing around with the Lift/Drag models for the fins and I realised one thing:

- A non-realistic model for the Drag component (two lines approximation)

Concerning the two lines model and the Drag component, it is consistent to use the same "S" shaped graph for both the Lift coefficient CL=f(alpha) and the Drag coefficient CD=f(alpha), as described [here](http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics). When I refer to "S" shaped graph, I mean the Cl vs alpha graph like presented [here](http://airfoiltools.com/airfoil/details?airfoil=naca0015-il).

However, it is not physically correct to have a drag vector oriented towards the inertial velocity of the sub when the alpha is negative: it should always be oriented opposite to the inertial velocity (as shown [here](http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics)) whatever the alpha value.
Therefore I have updated the code to generate a "V" shaped two lines approximation for the drag component (as shown [here](http://airfoiltools.com/airfoil/details?airfoil=naca0015-il), CD vs alpha).

Best regards,

Achille MARTIN