### PR TITLE
Fix compilation issues on Noetic/Gazebo11

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/CMakeLists.txt
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(uuv_gazebo_plugins)
 
 # Specify C++11 standard
-add_definitions(-std=c++11)
+add_definitions(-std=c++17)
 
-find_package(catkin REQUIRED COMPONENTS
-    gazebo_dev)
+find_package(catkin REQUIRED COMPONENTS gazebo_dev)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(Eigen3 REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/BuoyantObject.hh
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/BuoyantObject.hh
@@ -74,7 +74,7 @@ class BuoyantObject
   public: double GetGravity();
 
   /// \brief Sets bounding box
-  public: void SetBoundingBox(const ignition::math::Box &_bBox);
+  public: void SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox);
 
   /// \brief Adds a field in the hydroWrench map
   public: void SetStoreVector(std::string _tag);
@@ -120,7 +120,7 @@ class BuoyantObject
 
   /// \brief TEMP for calculation of the buoyancy
   /// force close to the surface
-  protected: ignition::math::Box boundingBox;
+  protected: ignition::math::AxisAlignedBox boundingBox;
 
   /// \brief Storage for hydrodynamic and hydrostatic forces and torques
   /// for debugging purposes

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
@@ -52,7 +52,7 @@ BuoyantObject::BuoyantObject(physics::LinkPtr _link)
   this->boundingBox = link->BoundingBox();
 #else
   math::Box bBox = link->GetBoundingBox();
-  this->boundingBox = ignition::math::Box(bBox.min.x, bBox.min.y, bBox.min.z,
+  this->boundingBox = ignition::math::AxisAlignedBox(bBox.min.x, bBox.min.y, bBox.min.z,
       bBox.max.x, bBox.max.y, bBox.max.z);
 #endif
   // Set neutrally buoyant flag to false
@@ -205,9 +205,9 @@ void BuoyantObject::ApplyBuoyancyForce()
 }
 
 /////////////////////////////////////////////////
-void BuoyantObject::SetBoundingBox(const ignition::math::Box &_bBox)
+void BuoyantObject::SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox)
 {
-  this->boundingBox = ignition::math::Box(_bBox);
+  this->boundingBox = ignition::math::AxisAlignedBox(_bBox);
 
   gzmsg << "New bounding box for " << this->link->GetName() << "::"
     << this->boundingBox << std::endl;

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
@@ -75,7 +75,7 @@ HydrodynamicModel::HydrodynamicModel(sdf::ElementPtr _sdf,
       double width = sdfModel->Get<double>("width");
       double length = sdfModel->Get<double>("length");
       double height = sdfModel->Get<double>("height");
-      ignition::math::Box boundingBox = ignition::math::Box(
+      ignition::math::AxisAlignedBox boundingBox = ignition::math::AxisAlignedBox(
         ignition::math::Vector3d(-width / 2, -length / 2, -height / 2),
         ignition::math::Vector3d(width / 2, length / 2, height / 2));
       // Setting the the bounding box from the given dimensions


### PR DESCRIPTION
- Fixed uuv_gazebo_plugins compilation issues on Noetic/Gazebo11


Test:
`roslaunch uuv_tutorial_disturbances tutorial_body_wrench.launch`

Passed a short sanity check for getting data from sensors and running without errors.


Edit:
I just saw that someone else made a fix with backward compatibility support for Melodic.
