### PR TITLE
Corrected world_ned transformation from world 

### DIFF
--- a/uuv_assistants/launch/publish_world_ned_frame.launch
+++ b/uuv_assistants/launch/publish_world_ned_frame.launch
@@ -1,4 +1,4 @@
 <launch>
   <node pkg="tf2_ros" type="static_transform_publisher" name="world_ned_frame_publisher"
-    args="0 0 0 1.5707963267948966 0 3.141592653589793 world world_ned" />
+    args="0 0 0 0 0 3.141592653589793 world world_ned" />
 </launch>

--- a/uuv_gazebo_worlds/models/ned_frame/model.sdf
+++ b/uuv_gazebo_worlds/models/ned_frame/model.sdf
@@ -22,7 +22,7 @@
 
       <link name="world_ned">
         <gravity>0</gravity>
-        <pose>0 0 0 3.14159265359 0 1.5707963267948966</pose>
+        <pose>0 0 0 3.14159265359 0 0</pose>
 
         <visual name="N_visual">
           <pose>0.25 0 0 1.5707963267948966 0 1.5707963267948966</pose>
@@ -41,7 +41,7 @@
         </visual>
 
         <visual name="E_visual">
-          <pose>0 0.25 0 1.5707963267948966 0 0</pose>
+          <pose>0 0.25 0 -1.5707963267948966 0 0</pose>
           <geometry>
             <cylinder>
               <radius>0.01</radius>


### PR DESCRIPTION
Dear UUV Sim devs,

Could you please review this pull request on the issue below?

Issue: the generated data of the PoseGTROSPlugin in its NED reference frame is not correct. 

Fix: This fix removes an extra rotation defined in the tf conversion from world to world_ned .

Detailed explanations: 
I have corrected what I suppose to be a typo in the publish_world_ned_frame.launch file as well as some little modifications in the model.sdf file of the ned_frame.

The world_ned generated by the static_transform_publisher in publish_world_ned_frame.launch possessed an extra rotation around the yaw axis of PI/2 that is superfluous as well as creating wrong data outputs for the PoseGTROSPlugin in its NED form.

As for the ned_frame model for Gazebo it is the same extra rotation that needs to be removed and the according changes for the visuals adapted accordingly.  

Best regards,

Vincent VITTORI 
 