### PR TITLE
Fixed crash caused by nan accelerations

### DIFF
--- a/uuv_gazebo_worlds/worlds/herkules_ship_wreck.world
+++ b/uuv_gazebo_worlds/worlds/herkules_ship_wreck.world
@@ -17,9 +17,9 @@
 <sdf version="1.4">
   <world name="munkholmen">
     <physics name="default_physics" default="true" type="ode">
-      <max_step_size>0.01</max_step_size>
+      <max_step_size>0.002</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>100</real_time_update_rate>
+      <real_time_update_rate>500</real_time_update_rate>
       <ode>
         <solver>
           <type>quick</type>


### PR DESCRIPTION
Previous physics parameters cause crashes when using ROV and Oberon 7 arm