### PR TITLE
Missing install of vehicle_keyboard_teleop.py

### DIFF
--- a/uuv_teleop/CMakeLists.txt
+++ b/uuv_teleop/CMakeLists.txt
@@ -10,5 +10,6 @@ install(DIRECTORY launch
         PATTERN "*~" EXCLUDE)
 
 catkin_install_python(PROGRAMS scripts/vehicle_teleop.py
+                               scripts/vehicle_keyboard_teleop.py
                                scripts/finned_uuv_teleop.py
                       DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
Adding this line in uuv_teleop/CMakeLists.txt allow to control UUV using keyboard.